### PR TITLE
compiler: add ghc9102 (nixpkgs 9.10.2) for the graphql-engine fork build

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -19,6 +19,8 @@ in {
 
       ghc912 = final.haskell.compiler.ghc912;
       ghc9122 = final.haskell.compiler.ghc912;
+
+      ghc9102 = final.haskell.compiler.ghc9102;
         };
 
     # Both `cabal-install` and `nix-tools` are needed for `cabalProject`


### PR DESCRIPTION
Map `ghc9102` to nixpkgs 9.10.2. graphql-engine pins GHC 9.10.2, which this fork did not expose (only 9.6/9.8/9.12). Needed to build it via haskell.nix (kronor#5696).