### PR TITLE
nixpkgs 26.05 compatibility (+ ghc914 aliases)

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -7,13 +7,18 @@ pkgs:
     # Only include derivations that exist in the current pkgs.
     # This allows us to use this mapping to be used in allPkgConfigWrapper.
     # See ./overlas
+    #
+    # An attribute may be present but throw on access (nixpkgs implements
+    # removed packages as throwing aliases, e.g. imagemagick6 in >= 26.05),
+    # so `x ? name` is not enough: we must also check the value evaluates.
+    presentAndEvaluable = x: name: x ? ${name} && (builtins.tryEval x.${name}).success;
     lookupAttrsIn = x: __mapAttrs (_pname: names:
         # The first entry is should be used for the version by allPkgConfigWrapper
         # so we need it to be present.
-        if __length names != 0 && x ? ${__head names}
+        if __length names != 0 && presentAndEvaluable x (__head names)
           then
             pkgs.lib.concatMap (
-              name: if x ? ${name} then [ x.${name} ] else []) names
+              name: if presentAndEvaluable x name then [ x.${name} ] else []) names
           else []);
   in lookupAttrsIn pkgs ({
     # Based on https://github.com/NixOS/cabal2nix/blob/11c68fdc79461fb74fa1dfe2217c3709168ad752/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs#L23

--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -158,4 +158,10 @@ in {
   #   error: inlining failed in call to ‘always_inline’ ‘void* memcpy(void*, const void*, size_t)’: target specific option mismatch
   packages.text.components.library.hardeningDisable =
     pkgs.lib.optionals pkgs.stdenv.hostPlatform.isMusl ["fortify"];
+
+  # ghc-debug-stub's cbits/stub.cpp calls inet_pton into a small buffer.
+  # glibc >= 2.42's _FORTIFY_SOURCE promotes this to a build error via the
+  # __inet_pton_chk_warn attribute-warning. Disable fortify for this package
+  # so it keeps building (the affected code path is the debug socket listener).
+  packages.ghc-debug-stub.components.library.hardeningDisable = ["fortify"];
 }

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -19,6 +19,9 @@ in {
 
       ghc912 = final.haskell.compiler.ghc912;
       ghc9122 = final.haskell.compiler.ghc912;
+
+      ghc914 = final.haskell.compiler.ghc914;
+      ghc9141 = final.haskell.compiler.ghc9141;
         };
 
     # Both `cabal-install` and `nix-tools` are needed for `cabalProject`

--- a/overlays/cabal-pkg-config.nix
+++ b/overlays/cabal-pkg-config.nix
@@ -39,9 +39,11 @@ final: prev:
     in prev.pkg-config.overrideAttrs (attrs:
       let
         # These vars moved from attrs to attrs.env in nixpkgs adc8900df1758eda56abd68f7d781d1df74fa531
-        # Support both for the time being.
-        targetPrefix = attrs.targetPrefix or attrs.env.targetPrefix;
-        baseBinName = attrs.baseBinName or attrs.env.baseBinName;
+        # and in later nixpkgs (>= 26.05) they are no longer in the mkDerivation
+        # args at all; they live as passthru on the wrapper derivation. Fall
+        # back through all three for the time being.
+        targetPrefix = attrs.targetPrefix or (attrs.env or { }).targetPrefix or prev.pkg-config.targetPrefix;
+        baseBinName = attrs.baseBinName or (attrs.env or { }).baseBinName or prev.pkg-config.baseBinName;
       in {
       installPhase = attrs.installPhase + ''
         mv $out/bin/${targetPrefix}${baseBinName} \
@@ -88,9 +90,11 @@ final: prev:
   cabalPkgConfigWrapper = prev.pkg-config.overrideAttrs (attrs: (
   let
     # These vars moved from attrs to attrs.env in nixpkgs adc8900df1758eda56abd68f7d781d1df74fa531
-    # Support both for the time being.
-    targetPrefix = attrs.targetPrefix or attrs.env.targetPrefix;
-    baseBinName = attrs.baseBinName or attrs.env.baseBinName;
+    # and in later nixpkgs (>= 26.05) they are no longer in the mkDerivation
+    # args at all; they live as passthru on the wrapper derivation. Fall
+    # back through all three for the time being.
+    targetPrefix = attrs.targetPrefix or (attrs.env or { }).targetPrefix or prev.pkg-config.targetPrefix;
+    baseBinName = attrs.baseBinName or (attrs.env or { }).baseBinName or prev.pkg-config.baseBinName;
   in {
     installPhase = attrs.installPhase + ''
       mv $out/bin/${targetPrefix}${baseBinName} \


### PR DESCRIPTION
Fixes needed to evaluate/build against **nixpkgs release-26.05**. Validated by a full kronor build against 26.05 (every dependency + application package compiled with these in place).

## Commits

**1. nixpkgs 26.05 compatibility** (needed on any GHC)
- `cabal-pkg-config.nix`: read pkg-config `targetPrefix`/`baseBinName` from the wrapper derivation passthru. nixpkgs >= 26.05 no longer keeps them in the mkDerivation args *or* `attrs.env`, so the old `attrs.targetPrefix or attrs.env.targetPrefix` fallback threw `attribute 'env' missing`.
- `pkgconf-nixpkgs-map.nix`: skip attributes that exist but throw on access. nixpkgs >= 26.05 implements removed packages (e.g. `imagemagick6`) as throwing aliases, so a plain `?` existence check passes and the subsequent access throws.
- `configuration-nix.nix`: disable `fortify` for `ghc-debug-stub`. glibc >= 2.42's `_FORTIFY_SOURCE` promotes its `inet_pton` buffer warning to a build error.

**2. ghc914/ghc9141 compiler aliases** (optional; prep for a future GHC 9.14 bump)
- Maps `compiler-nix-name` `ghc914`/`ghc9141` to nixpkgs' GHC 9.14 attributes. Not used by default; safe to drop from this PR if you'd rather keep it 26.05-only.

## Notes
GHC 9.14 itself is **not** adopted here — a separate effort hit a GHC 9.14.1 `-dynamic-too` + `.hs-boot` interface-hash bug and is parked until GHC ships a fix.

---
Tracked in kronor-io/kronor#5745
